### PR TITLE
New supported cube: Chinese cube 4x4x4 set based on STC15F2K60S2 chip

### DIFF
--- a/examples/MD_Cubo_Demo/MD_Cubo_Demo.ino
+++ b/examples/MD_Cubo_Demo/MD_Cubo_Demo.ino
@@ -9,6 +9,7 @@
 // Pick the include file for the right cube
 //#include "MD_Cubo_4x4_72xx.h" 
 //#include "MD_Cubo_4x4_ICS595.h"
+//#include "MD_Cubo_4x4_STC.h"
 #include "MD_Cubo_8x8_jC.h"
 
 // Define the cube object
@@ -20,6 +21,9 @@ MD_Cubo_ICS595  C;
 #endif
 #ifdef MD_CUBO_8x8_JC_H
 MD_Cubo_JC	C;
+#endif
+#ifdef MD_CUBO_4x4_STC_H
+MD_Cubo_STC  C;
 #endif
 
 #define RANDOM_CYCLE  1 // 1 for random selection, 0 for sequential cycle

--- a/examples/MD_Cubo_Test/MD_Cubo_Test.ino
+++ b/examples/MD_Cubo_Test/MD_Cubo_Test.ino
@@ -4,6 +4,7 @@
 // Pick the include file for the right cube
 //#include "MD_Cubo_4x4_72xx.h" 
 //#include "MD_Cubo_4x4_ICS595.h"
+//#include "MD_Cubo_4x4_STC.h"
 #include "MD_Cubo_8x8_jC.h"
 
 // Define the cube object
@@ -15,6 +16,9 @@ MD_Cubo_ICS595  C;
 #endif
 #ifdef MD_CUBO_8x8_JC_H
 MD_Cubo_JC	C;
+#endif
+#ifdef MD_CUBO_4x4_STC_H
+MD_Cubo_STC  C;
 #endif
 
 #define	DEBUG	0		///< Enable or disable (default) debugging output from the example

--- a/src/MD_Cubo_4x4_STC.cpp
+++ b/src/MD_Cubo_4x4_STC.cpp
@@ -1,0 +1,56 @@
+#include <MD_Cubo.h>
+#include "MD_Cubo_4x4_STC.h"
+
+void MD_Cubo_STC::begin()
+{
+  byte i;
+  Serial.begin(57600);
+  for (i = 0; i < 50; i++)
+  {
+    Serial.write(0xAD);
+    delay(100);
+  }
+  this->clear();
+  this->update();
+  delay(1000);
+}
+
+
+void MD_Cubo_STC::update()
+//Update the cube LEDs
+{
+  Serial.write(0xEA);
+  Serial.write(_columns, COLUMN_COUNT);
+  Serial.write(0xEB);
+  Serial.write(0xEB);
+}
+
+
+void MD_Cubo_STC::setVoxel(boolean p, uint8_t x, uint8_t y, uint8_t z)
+{
+  uint8_t pixelcolor;
+  if ((x>CUBE_SIZE) || (y>CUBE_SIZE) || (z>CUBE_SIZE))
+    return;
+  
+  if (p==true)
+  {
+    pixelcolor=0xff;
+  }
+  else
+  {
+    pixelcolor=_intensity;
+  }
+  _columns[x*12+y*48+z*3]=pixelcolor;
+  _columns[x*12+y*48+z*3+1]=pixelcolor;
+  _columns[x*12+y*48+z*3+2]=pixelcolor;
+  
+}
+
+boolean MD_Cubo_STC::getVoxel(uint8_t x, uint8_t y, uint8_t z)
+{
+  if ((x>CUBE_SIZE) || (y>CUBE_SIZE) || (z>CUBE_SIZE))
+    return(false);
+
+  
+  return((_columns[x*12+y*48+z*3]+_columns[x*12+y*48+z*3+1]+_columns[x*12+y*48+z*3+2])>0);
+}

--- a/src/MD_Cubo_4x4_STC.cpp
+++ b/src/MD_Cubo_4x4_STC.cpp
@@ -1,13 +1,15 @@
 #include <MD_Cubo.h>
+#include <SoftwareSerial.h>
 #include "MD_Cubo_4x4_STC.h"
+SoftwareSerial CubeSerial(10, 11); // RX, TX
 
 void MD_Cubo_STC::begin()
 {
   byte i;
-  Serial.begin(57600);
+  CubeSerial.begin(57600);
   for (i = 0; i < 50; i++)
   {
-    Serial.write(0xAD);
+    CubeSerial.write(0xAD);
     delay(100);
   }
   this->clear();
@@ -19,10 +21,10 @@ void MD_Cubo_STC::begin()
 void MD_Cubo_STC::update()
 //Update the cube LEDs
 {
-  Serial.write(0xEA);
-  Serial.write(_columns, COLUMN_COUNT);
-  Serial.write(0xEB);
-  Serial.write(0xEB);
+  CubeSerial.write(0xEA);
+  CubeSerial.write(_columns, COLUMN_COUNT);
+  CubeSerial.write(0xEB);
+  CubeSerial.write(0xEB);
 }
 
 

--- a/src/MD_Cubo_4x4_STC.h
+++ b/src/MD_Cubo_4x4_STC.h
@@ -21,36 +21,34 @@
 #endif
 
 /**
-\page pagePAULRB4x4 PaulRB DIY Implementation
-PaulRB 4x4 Cube
+\page Zirrfa DIY Implementation
+Zirrfa 4x4 Cube
 ---------------
-Source: Arduino Forum "4x4x4 LED Cube with ATtiny85 and MAX7219" at http://forum.arduino.cc/index.php?topic=226262.0
+Source: AliExpress "Zirrfa 4x4x4 RGB LED Cube" at https://www.aliexpress.com/item/NEW-3D-4X4X4-RGB-cubeeds-Full-Color-LED-Light-display-Electronic-DIY-Kit-3d4-4-4/32793425203.html
 
-![PaulRB 4x4 Cube] (PaulRB_image.jpg "PaulRB 4x4 Cube")
+![Zirrfa 4x4 Cube] (Zirrfa_image.jpg "Zirrfa 4x4 Cube")
 
-The PaulRB cube is implemented as a single sided PCB for DIY projects. It has a single MD_MAX7219 IC with an SPI 
-interface to the Arduino controller or an ATTiny85 on the board itself, and is therefore a 'set and forget' type 
+The Zirrfa cube can be bought online as a DIY soldering set. It has a STC15F2K60S2 IC with a SPI 
+interface to the Arduino controller and is therefore a 'set and forget' type 
 of device.
 
-The hardware architecture implemented is shown in the figure below. Essentially, the 7219 IC's 64 bits 
-(8 Digits x 8 Segments) are remapped into the 64 LEDs of the cube in a non-linear manner.
+Note: To use this implementation you need to install the SofSerial Arduino library. 
+Connect the cube RX to pin 11 (TX) of the Arduino as this is currently the default serial interface. (This should work with most Arduinos).
 
-![PaulRB Cube Schematic] (PaulRB_Schematic.png "PaulRB Cube Schematic")
 
 ###Implementation Overview###
 The software implements an SPI interface through the standard Arduino SPI object.
 
-Cube data is buffered in memory organised as the digits of the 7219 IC (8 bytes). The setVoxel() function uses a 
-lookup table to find the bits representing the XYZ position for each LED in the cube. The cube data is held in 
-memory buffers until an update() call is made, at which point it is entirely written to the cube through the SPI 
-interface.
+Cube data is buffered in memory in a serial 192 byte string, which represents the 4x4x4x3 bytes 
+(the dimensions of the cube LEDs multiplied with 3 byte values (RGB) to set the color)
+The cube data is held in memory buffers until an update() call is made, at which point it is 
+entirely written to the cube through the SPI interface.
 
-The intensity values 0..255 are remapped to 0..15 levels available in the MAX7219 IC (divide by 16).  
 */
 
 
 #define CUBE_SIZE 4		///< Cube size in the X, Y and Z axis
-#define MAX_INTENSITY 254
+#define MAX_INTENSITY 254 // @todo This will be removed at some point
 #define COLUMN_COUNT 192 /// 4x4x4 LEDs x 3 RGB color values
 
 
@@ -67,8 +65,8 @@ class MD_Cubo_STC: public MD_Cubo
   uint8_t size(axis_t axis) { return CUBE_SIZE; };
   
   private:
-  uint8_t _columns[COLUMN_COUNT]; ///< Holds the current bit pattern for each layer of the cube
-  uint8_t _intensity;  // Can hold an RGB value
+  uint8_t _columns[COLUMN_COUNT]; ///< Holds the current byte pattern for all LEDs of the cube
+  uint8_t _intensity;  // @todo: Convert to RGB value
   
 };
 

--- a/src/MD_Cubo_4x4_STC.h
+++ b/src/MD_Cubo_4x4_STC.h
@@ -1,0 +1,75 @@
+#ifndef MD_CUBO_4x4_STC_H
+#define MD_CUBO_4x4_STC_H
+
+/**
+ * \file
+ * \brief Header file for the MD_Cubo STC class
+ */
+
+#define	DEBUG_STC	0		///< Enable or disable (default) debugging output from the example
+
+#if DEBUG_STC
+#define	PRINT(s, v)		{ Serial.print(F(s)); Serial.print(v); }		  ///< Print a string followed by a value (decimal)
+#define	PRINTX(s, v)	{ Serial.print(F(s)); Serial.print(v, HEX); }	///< Print a string followed by a value (hex)
+#define	PRINTB(s, v)	{ Serial.print(F(s)); Serial.print(v, BIN); }	///< Print a string followed by a value (binary)
+#define	PRINTS(s)		  { Serial.print(F(s)); }							          ///< Print a string
+#else
+#define	PRINT(s, v)		///< Print a string followed by a value (decimal)
+#define	PRINTX(s, v)	///< Print a string followed by a value (hex)
+#define	PRINTB(s, v)	///< Print a string followed by a value (binary)
+#define	PRINTS(s)		  ///< Print a string
+#endif
+
+/**
+\page pagePAULRB4x4 PaulRB DIY Implementation
+PaulRB 4x4 Cube
+---------------
+Source: Arduino Forum "4x4x4 LED Cube with ATtiny85 and MAX7219" at http://forum.arduino.cc/index.php?topic=226262.0
+
+![PaulRB 4x4 Cube] (PaulRB_image.jpg "PaulRB 4x4 Cube")
+
+The PaulRB cube is implemented as a single sided PCB for DIY projects. It has a single MD_MAX7219 IC with an SPI 
+interface to the Arduino controller or an ATTiny85 on the board itself, and is therefore a 'set and forget' type 
+of device.
+
+The hardware architecture implemented is shown in the figure below. Essentially, the 7219 IC's 64 bits 
+(8 Digits x 8 Segments) are remapped into the 64 LEDs of the cube in a non-linear manner.
+
+![PaulRB Cube Schematic] (PaulRB_Schematic.png "PaulRB Cube Schematic")
+
+###Implementation Overview###
+The software implements an SPI interface through the standard Arduino SPI object.
+
+Cube data is buffered in memory organised as the digits of the 7219 IC (8 bytes). The setVoxel() function uses a 
+lookup table to find the bits representing the XYZ position for each LED in the cube. The cube data is held in 
+memory buffers until an update() call is made, at which point it is entirely written to the cube through the SPI 
+interface.
+
+The intensity values 0..255 are remapped to 0..15 levels available in the MAX7219 IC (divide by 16).  
+*/
+
+
+#define CUBE_SIZE 4		///< Cube size in the X, Y and Z axis
+#define MAX_INTENSITY 254
+#define COLUMN_COUNT 192 /// 4x4x4 LEDs x 3 RGB color values
+
+
+class MD_Cubo_STC: public MD_Cubo
+{
+  public:
+  MD_Cubo_STC(): MD_Cubo(CUBE_SIZE) {return;};
+  ~MD_Cubo_STC() {return;};
+  void begin();
+  void update();
+  void setVoxel(boolean p, uint8_t x, uint8_t y, uint8_t z);
+  boolean getVoxel(uint8_t x, uint8_t y, uint8_t z);
+  void clear(boolean p = false) { memset(_columns, (p ? 0xff : 0), COLUMN_COUNT); };
+  uint8_t size(axis_t axis) { return CUBE_SIZE; };
+  
+  private:
+  uint8_t _columns[COLUMN_COUNT]; ///< Holds the current bit pattern for each layer of the cube
+  uint8_t _intensity;  // Can hold an RGB value
+  
+};
+
+#endif


### PR DESCRIPTION
This is a driver for a an ZIRRFA RGB 4x4x4 cube set you can buy on the AliExpress platform for little money.
It uses a STC15F2K60S2 to run a default demo sequence, however you can control it by using a serial port.
(Example: https://www.aliexpress.com/item/NEW-3D-4X4X4-RGB-cubeeds-Full-Color-LED-Light-display-Electronic-DIY-Kit-3d4-4-4/32793425203.html )
I tested it and it works with all demos.

However it is work in progress.
